### PR TITLE
Fix when db is not provided, like on sentinels

### DIFF
--- a/lib/redic/client.rb
+++ b/lib/redic/client.rb
@@ -41,7 +41,7 @@ class Redic
 
       if @uri.scheme == "redis"
         @uri.password && assert_ok(call("AUTH", @uri.password))
-        @uri.path     && assert_ok(call("SELECT", @uri.path[1..-1]))
+        @uri.path != "" && assert_ok(call("SELECT", @uri.path[1..-1]))
       end
     end
 

--- a/tests/redic_test.rb
+++ b/tests/redic_test.rb
@@ -55,6 +55,11 @@ test "error when authenticating from url" do
   end
 end
 
+test "Can connect to sentinel" do
+  c2 = Redic.new "redis://localhost:26379"
+  c2.call "SENTINEL", "masters"
+end
+
 test "timeout" do |c1|
 
   # Default timeout is 10 seconds


### PR DESCRIPTION
I got an error when connecting to sentinels. Redic called anyway the "SELECT" command which Redis Sentinels don't understand. I added another check before calling it.
