### PR TITLE
Allow timeout to be changed

### DIFF
--- a/lib/redic.rb
+++ b/lib/redic.rb
@@ -68,6 +68,10 @@ class Redic
     @client.timeout
   end
 
+  def timeout=(timeout)
+    @client.timeout = timeout
+  end
+
   def quit
     @client.quit
   end

--- a/lib/redic/client.rb
+++ b/lib/redic/client.rb
@@ -6,7 +6,7 @@ class Redic
     EMPTY = "".freeze
     SLASH = "/".freeze
 
-    attr :timeout
+    attr_accessor :timeout
 
     def initialize(url, timeout)
       @semaphore = Mutex.new

--- a/tests/redic_test.rb
+++ b/tests/redic_test.rb
@@ -83,6 +83,11 @@ test "timeout" do |c1|
   c2 = Redic.new(REDIS_URL, 200_000)
 
   assert_equal 200_000, c2.timeout
+
+  # Change timeout to 5 seconds
+  c2.timeout = 5_000_000
+
+  assert_equal 5_000_000, c2.timeout
 end
 
 test "normal commands" do |c|


### PR DESCRIPTION
Hi @soveran,

Thank you for all your contributions in the Redis world 🙇 

This is a simple PR that allows changing the timeout of the Redic object, without creating a new object or using `instance_variable_set` hacks as seen in https://github.com/soveran/redisent/issues/1

Before:

```ruby
require 'redic'

redic = Redic.new(url = 'redis://127.0.0.1:6379', timeout= 1_000)

redic.timeout
# => 1000

redic.instance_variable_get('@client').instance_variable_set('@timeout', 42)

redic.timeout
# => 42

redic.client.timeout
# => 42
```

After:

```ruby
require 'redic'

redic = Redic.new(url = 'redis://127.0.0.1:6379', timeout= 1_000)

redic.timeout
# => 1000

redic.timeout = 42 # same as redic.client.timeout = 42

redic.timeout
# => 42

redic.client.timeout
# => 42
```

Let me know, thanks for looking at it ✌️ 

