### PR TITLE
Connect to ENV["REDIS_URL"] by default

### DIFF
--- a/lib/redic.rb
+++ b/lib/redic.rb
@@ -4,7 +4,7 @@ class Redic
   attr :url
   attr :client
 
-  def initialize(url = "redis://127.0.0.1:6379", timeout = 10_000_000)
+  def initialize(url = ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379"), timeout = 10_000_000)
     @url = url
     @client = Redic::Client.new(url, timeout)
     @buffer = Hash.new { |h, k| h[k] = [] }


### PR DESCRIPTION
This makes it so that if you have a `REDIS_URL` environment variable set, redic will connect to that, and if that's not set it will connect to the default `redis://127.0.0.1:6379` address.

cc @cyx @soveran 